### PR TITLE
Asset without port bug fix

### DIFF
--- a/batea/core/csv_parser.py
+++ b/batea/core/csv_parser.py
@@ -52,7 +52,7 @@ class CSVFileParser:
                                   hostname=row.get('hostname', None),
                                   os_info={'name': row.get('os_name', None)}))
 
-            if row.get('port', None) not in [0, '', None]:
+            if row.get('port', None) not in ['', None]:
                 hosts[-1].ports.append(Port(
                     port=int(float(row.get('port', None))),
                     protocol=row.get('protocol', None),

--- a/batea/core/csv_parser.py
+++ b/batea/core/csv_parser.py
@@ -52,13 +52,14 @@ class CSVFileParser:
                                   hostname=row.get('hostname', None),
                                   os_info={'name': row.get('os_name', None)}))
 
-            hosts[-1].ports.append(Port(
-                port=int(row.get('port', None)),
-                protocol=row.get('protocol', None),
-                state=row.get('state', None),
-                service=row.get('service', None),
-                software=row.get('software_banner', None),
-                version=row.get('version', None),
-                cpe=row.get('cpe', None)
-            ))
+            if row.get('port', None) not in [0, '', None]:
+                hosts[-1].ports.append(Port(
+                    port=int(float(row.get('port', None))),
+                    protocol=row.get('protocol', None),
+                    state=row.get('state', None),
+                    service=row.get('service', None),
+                    software=row.get('software_banner', None),
+                    version=row.get('version', None),
+                    cpe=row.get('cpe', None)
+                ))
         return hosts

--- a/tests/samples/batea_null_csv
+++ b/tests/samples/batea_null_csv
@@ -1,4 +1,3 @@
 ipv4,hostname,os_name,port,state,protocol,service,software_banner
 10.251.53.100,,Linux,111,open,tcp,rpcbind,
-10.251.53.188,,Linux,0,open,tcp,X11,
 10.251.53.188,,Linux,,open,tcp,X11,

--- a/tests/samples/batea_null_csv
+++ b/tests/samples/batea_null_csv
@@ -1,0 +1,4 @@
+ipv4,hostname,os_name,port,state,protocol,service,software_banner
+10.251.53.100,,Linux,111,open,tcp,rpcbind,
+10.251.53.188,,Linux,0,open,tcp,X11,
+10.251.53.188,,Linux,,open,tcp,X11,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -134,7 +134,7 @@ def test_csv_parser_doesnt_generates_list_of_ports_if_port_number_is_null_or_zer
     parser = CSVFileParser()
     with open(csv_null_filename, 'r') as f:
         hosts = list(parser.load_hosts(f))
-    print(hosts[1].ports)
+
     assert len(hosts) == 2
     assert len(hosts[0].ports) == 1
     assert len(hosts[1].ports) == 0

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -22,8 +22,8 @@ nmap_full_filename = join(dirname(__file__), "samples/single_full.xml")
 nmap_base_filename = join(dirname(__file__), "samples/single_base.xml")
 
 csv_short_filename = join(dirname(__file__), 'samples/batea_simple_csv')
-
 csv_long_filename = join(dirname(__file__), 'samples/batea_long_csv')
+csv_null_filename = join(dirname(__file__), 'samples/batea_null_csv')
 
 
 def test_nmap_parser_generates_list_of_hosts():
@@ -128,3 +128,13 @@ def test_csv_parser_generates_list_of_ports_for_each_hosts():
     assert len(hosts[-1].ports) == 12
     assert hosts[-1].ports[0].port == 853
     assert hosts[-1].ports[0].service == 'unknown'
+
+
+def test_csv_parser_doesnt_generates_list_of_ports_if_port_number_is_null_or_zero():
+    parser = CSVFileParser()
+    with open(csv_null_filename, 'r') as f:
+        hosts = list(parser.load_hosts(f))
+    print(hosts[1].ports)
+    assert len(hosts) == 2
+    assert len(hosts[0].ports) == 1
+    assert len(hosts[1].ports) == 0


### PR DESCRIPTION
Pandas automatically convert columns with integer and null values as float, but the numpy csv ready only reads string. So the CSV parser will transform string into float then integer for port number as it is the most general order of operation.